### PR TITLE
Fix ESLint Configuraiton

### DIFF
--- a/web/frontend/.eslintrc.cjs
+++ b/web/frontend/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended"
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -18,7 +19,7 @@ module.exports = {
     ecmaVersion: "latest",
     sourceType: "module",
   },
-  plugins: ["react", "@typescript-eslint", "plugin:prettier/recommended"],
+  plugins: ["react", "@typescript-eslint"],
   rules: {
     "react/react-in-jsx-scope": 0,
   },


### PR DESCRIPTION
When attempting to lint the project, ESLint will fail with the error `ESLint couldn't find the plugin "eslint-plugin-plugin:prettier/recommended".` as prettier/recommended is a config you should extend, not a plugin.

This pull request fixes this issue, making it possible to lint the frontend code with ESLint.

<hr/>

Note that if you run ESLint with this merged, it will modify some files on the frontend.

I would additionally make a simple .editorconfig file that matches the Prettier configuration, as some Code Editors/IDEs don't automatically get indendation, line endings etc. from Prettier configs, but do from EditorConfig files (such as JetBrains IDEs.)

I opened another pull request, #2, to make both changes.